### PR TITLE
Fix #38: Don't update patient if the selected node is not a patient one

### DIFF
--- a/components/NetworkMap/index.js
+++ b/components/NetworkMap/index.js
@@ -88,11 +88,18 @@ const NetworkMap = ({
 
   const events = {
     select: function(event) {
-      const selectedPatientId = event.nodes[0]
-      if (selectedPatientId) {
-        // As per the vis.js API, event.pointer.canvas points to the selected node within the canvas
-        // which in our case is the patient. Inject this into the update logic.
-        selectPatient({ id: selectedPatientId, coords: event.pointer.canvas })
+      const selectedNodeId = event.nodes[0]
+      const selectedNode = graph.nodes.find(v => v.id === selectedNodeId)
+      if (selectedNode) {
+        switch (selectedNode.group) {
+          case 'patient':
+            // As per the vis.js API, event.pointer.canvas points to the selected node within the canvas
+            // which in our case is the patient. Inject this into the update logic.
+            selectPatient({ id: selectedNode.id, coords: event.pointer.canvas })
+            break
+          case 'city':
+          default:
+        }
       }
     },
   }

--- a/components/Redux/reducers.js
+++ b/components/Redux/reducers.js
@@ -33,16 +33,17 @@ export default (state = initialState, action) => {
     }
     case actionTypes.UPDATE_PATIENTS: {
       const { patients } = action.payload
-      return { ...state, patients: patients, patient: patients.byId[251] }
+      return { ...state, patients: patients, patient: patients.byId[251] } // `P1` in code
     }
     case actionTypes.SELECT_PATIENT: {
       const { id, coords } = action.payload
       const { patients } = state
+      const existingPatient = patients.byId[id]
       const patient = {
         ...patients.byId[id],
         coords
       }
-      return { ...state, patient }
+      return existingPatient ? { ...state, patient } : state
     }
     default:
       return state

--- a/util/parse.js
+++ b/util/parse.js
@@ -119,6 +119,7 @@ export const rowsToGraph = rows => {
       label: 'P' + row.patientId,
       shape: 'image',
       image: getIcon(row),
+      group: 'patient'
     }
 
     graph = dotProp.set(graph, 'nodes', list => [...list, node])


### PR DESCRIPTION
Also allow other node selection use cases.